### PR TITLE
Add basic KPI and chart pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+.web
+.states
+assets/external/
+*.db
+*.py[cod]
 __pycache__/
 .web/
 
+*.zip

--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ This repository contains a minimal [Reflex](https://github.com/reflex-dev/reflex
    ```
    The application will be available at `http://localhost:3000`.
 
-The app currently displays a simple "Hello, World!" page as a starting point for future development.
+The app now includes a minimal dashboard with mock KPIs and sample charts.
+Visit `/kpis` to see example metrics and `/charts` for simple line and bar
+charts that illustrate the art of the possible with Reflex.

--- a/cost_to_serve/cost_to_serve.py
+++ b/cost_to_serve/cost_to_serve.py
@@ -4,6 +4,19 @@ import reflex as rx
 
 from rxconfig import config
 
+mock_line_data = [
+    {"month": "Jan", "cost": 3200},
+    {"month": "Feb", "cost": 3400},
+    {"month": "Mar", "cost": 3000},
+    {"month": "Apr", "cost": 3600},
+]
+
+mock_bar_data = [
+    {"warehouse": "A", "orders": 400},
+    {"warehouse": "B", "orders": 300},
+    {"warehouse": "C", "orders": 500},
+]
+
 
 class State(rx.State):
     """Application state."""
@@ -13,11 +26,80 @@ class State(rx.State):
 def index() -> rx.Component:
     """The home page of the app."""
     return rx.center(
-        rx.heading("Hello, World!"),
+        rx.vstack(
+            rx.heading("Cost to Serve POC"),
+            rx.link("View KPIs", href="/kpis"),
+            rx.link("View Charts", href="/charts"),
+            spacing="4",
+        ),
         min_height="100vh",
     )
 
 
 app = rx.App()
 app.add_page(index)
+
+
+def kpi_page() -> rx.Component:
+    """Display mock KPIs."""
+    return rx.vstack(
+        rx.heading("Mock KPIs"),
+        rx.hstack(
+            rx.box(
+                rx.text("Total Orders"),
+                rx.text("1,250"),
+                padding="1em",
+                border="1px solid #ccc",
+                border_radius="md",
+            ),
+            rx.box(
+                rx.text("Avg Cost per Order"),
+                rx.text("$35"),
+                padding="1em",
+                border="1px solid #ccc",
+                border_radius="md",
+            ),
+            rx.box(
+                rx.text("On-time Delivery"),
+                rx.text("95%"),
+                padding="1em",
+                border="1px solid #ccc",
+                border_radius="md",
+            ),
+            spacing="6",
+        ),
+        padding="4",
+        spacing="6",
+    )
+
+
+def charts_page() -> rx.Component:
+    """Display mock charts using Recharts."""
+    return rx.vstack(
+        rx.heading("Mock Charts"),
+        rx.recharts.line_chart(
+            rx.recharts.line(data_key="cost", stroke="#8884d8"),
+            rx.recharts.x_axis(data_key="month"),
+            rx.recharts.y_axis(),
+            rx.recharts.tooltip(),
+            rx.recharts.legend(),
+            data=mock_line_data,
+            height=300,
+        ),
+        rx.recharts.bar_chart(
+            rx.recharts.bar(data_key="orders", fill="#82ca9d"),
+            rx.recharts.x_axis(data_key="warehouse"),
+            rx.recharts.y_axis(),
+            rx.recharts.tooltip(),
+            rx.recharts.legend(),
+            data=mock_bar_data,
+            height=300,
+        ),
+        padding="4",
+        spacing="6",
+    )
+
+
+app.add_page(kpi_page, route="/kpis", title="KPIs")
+app.add_page(charts_page, route="/charts", title="Charts")
 


### PR DESCRIPTION
## Summary
- create a simple dashboard with KPI and chart pages
- show example metrics and line/bar charts
- update README with new routes
- extend `.gitignore` for build artifacts

## Testing
- `reflex export`

------
https://chatgpt.com/codex/tasks/task_e_685273f6793c832e9976e490c76a07ed